### PR TITLE
Update README to include info on default rules and conf file example

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ for [ModSecurity](http://www.modsecurity.org) web application firewall
 
 [![Docker Repository on Quay](https://quay.io/repository/jcmoraisjr/modsecurity-spoa/status "Docker Repository on Quay")](https://quay.io/repository/jcmoraisjr/modsecurity-spoa)
 
-## SPOP and HAProxy version
+## SPOP and HAProxy Version
 
 The current [SPOP](https://www.haproxy.org/download/2.2/doc/SPOE.txt) version is v2, used since modsecurity-spoa v0.4. This agent version works on HAProxy 1.8.10 and newer.
 
 SPOP v1 is used on modsecurity-spoa v0.1 to v0.3. This agent version works on HAProxy up to 1.8.9.
 
-## Agent configuration
+## Agent Configuration
 
 Command line syntax:
 
@@ -24,50 +24,22 @@ $ docker run -p 12345:12345 quay.io/jcmoraisjr/modsecurity-spoa [options] [-- <c
 The only difference is that the later supports only one filename. All config-files found
 will be used, included in the same order as they have been declared.
 
-In order to contain the original rules that are included in the setup without config-files, you should include the following in your `crs-setup.conf` file (if required). Running the Docker image without these included will disable a lot of ModSecurity's default rules.
+### Default Configuration Files
 
+In order to contain the original rules that are included in the default setup, you should copy the following files from the running image:
 ```
-Include /etc/modsecurity/owasp-modsecurity-crs/rules/REQUEST-900-EXCLUSION-RULES-BEFORE-CRS.conf
-Include /etc/modsecurity/owasp-modsecurity-crs/rules/REQUEST-901-INITIALIZATION.conf
-Include /etc/modsecurity/owasp-modsecurity-crs/rules/REQUEST-903.9001-DRUPAL-EXCLUSION-RULES.conf
-Include /etc/modsecurity/owasp-modsecurity-crs/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
-Include /etc/modsecurity/owasp-modsecurity-crs/rules/REQUEST-903.9003-NEXTCLOUD-EXCLUSION-RULES.conf
-Include /etc/modsecurity/owasp-modsecurity-crs/rules/REQUEST-903.9004-DOKUWIKI-EXCLUSION-RULES.conf
-Include /etc/modsecurity/owasp-modsecurity-crs/rules/REQUEST-903.9005-CPANEL-EXCLUSION-RULES.conf
-Include /etc/modsecurity/owasp-modsecurity-crs/rules/REQUEST-903.9006-XENFORO-EXCLUSION-RULES.conf
-Include /etc/modsecurity/owasp-modsecurity-crs/rules/REQUEST-905-COMMON-EXCEPTIONS.conf
-Include /etc/modsecurity/owasp-modsecurity-crs/rules/REQUEST-910-IP-REPUTATION.conf
-Include /etc/modsecurity/owasp-modsecurity-crs/rules/REQUEST-911-METHOD-ENFORCEMENT.conf
-Include /etc/modsecurity/owasp-modsecurity-crs/rules/REQUEST-912-DOS-PROTECTION.conf
-Include /etc/modsecurity/owasp-modsecurity-crs/rules/REQUEST-913-SCANNER-DETECTION.conf
-Include /etc/modsecurity/owasp-modsecurity-crs/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
-Include /etc/modsecurity/owasp-modsecurity-crs/rules/REQUEST-921-PROTOCOL-ATTACK.conf
-Include /etc/modsecurity/owasp-modsecurity-crs/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
-Include /etc/modsecurity/owasp-modsecurity-crs/rules/REQUEST-931-APPLICATION-ATTACK-RFI.conf
-Include /etc/modsecurity/owasp-modsecurity-crs/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
-Include /etc/modsecurity/owasp-modsecurity-crs/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
-Include /etc/modsecurity/owasp-modsecurity-crs/rules/REQUEST-934-APPLICATION-ATTACK-NODEJS.conf
-Include /etc/modsecurity/owasp-modsecurity-crs/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
-Include /etc/modsecurity/owasp-modsecurity-crs/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
-Include /etc/modsecurity/owasp-modsecurity-crs/rules/REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION.conf
-Include /etc/modsecurity/owasp-modsecurity-crs/rules/REQUEST-944-APPLICATION-ATTACK-JAVA.conf
-Include /etc/modsecurity/owasp-modsecurity-crs/rules/REQUEST-949-BLOCKING-EVALUATION.conf
-Include /etc/modsecurity/owasp-modsecurity-crs/rules/RESPONSE-950-DATA-LEAKAGES.conf
-Include /etc/modsecurity/owasp-modsecurity-crs/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
-Include /etc/modsecurity/owasp-modsecurity-crs/rules/RESPONSE-952-DATA-LEAKAGES-JAVA.conf
-Include /etc/modsecurity/owasp-modsecurity-crs/rules/RESPONSE-953-DATA-LEAKAGES-PHP.conf
-Include /etc/modsecurity/owasp-modsecurity-crs/rules/RESPONSE-954-DATA-LEAKAGES-IIS.conf
-Include /etc/modsecurity/owasp-modsecurity-crs/rules/RESPONSE-959-BLOCKING-EVALUATION.conf
-Include /etc/modsecurity/owasp-modsecurity-crs/rules/RESPONSE-980-CORRELATION.conf
-Include /etc/modsecurity/owasp-modsecurity-crs/rules/RESPONSE-999-EXCLUSION-RULES-AFTER-CRS.conf
+docker run -p 12345:12345 quay.io/jcmoraisjr/modsecurity-spoa -n 1
+docker cp ${containerId}:/etc/modsecurity/modsecurity.conf ./
+docker cp ${containerId}:/etc/modsecurity/owasp-modsecurity-crs.conf ./
 ```
 
-An example of using config files would be.
+Use the copied files in your run command:
 ```
-cd rootfs
-# download and configure conf files in rootfs directory
-docker run -p 12345:12345 -v $(pwd):/root/ quay.io/jcmoraisjr/modsecurity-spoa -n 1 -- /root/modsecurity.conf /root/crs-setup.conf
+# download and configure conf files in rootfs directory (ex./ crs-setup.conf)
+docker run -p 12345:12345 -v $(pwd):/etc/modsecurity/ quay.io/jcmoraisjr/modsecurity-spoa -n 1 -- /etc/modsecurity/modsecurity.conf /etc/modsecurity/owasp-modsecurity-crs.conf /etc/modsecurity/crs-setup.conf
 ```
+
+### Running without Config Files
 
 If no config-file is declared, the following will be used:
 

--- a/README.md
+++ b/README.md
@@ -24,19 +24,20 @@ $ docker run -p 12345:12345 quay.io/jcmoraisjr/modsecurity-spoa [options] [-- <c
 The only difference is that the later supports only one filename. All config-files found
 will be used, included in the same order as they have been declared.
 
-### Default Configuration Files
+### Customize the Configuration Files
 
-In order to contain the original rules that are included in the default setup, you should copy the following files from the running image:
+In order to use the default configuration in your customization, you should copy the following files from the image:
 ```
-docker run -p 12345:12345 quay.io/jcmoraisjr/modsecurity-spoa -n 1
-docker cp ${containerId}:/etc/modsecurity/modsecurity.conf ./
-docker cp ${containerId}:/etc/modsecurity/owasp-modsecurity-crs.conf ./
+docker create --name modsec quay.io/jcmoraisjr/modsecurity-spoa
+docker cp modsec:/etc/modsecurity/modsecurity.conf .
+docker cp modsec:/etc/modsecurity/owasp-modsecurity-crs.conf .
+docker rm modsec
 ```
 
-Use the copied files in your run command:
+Download and customize the configuration files for either the [ModSecurity repository](https://github.com/SpiderLabs/ModSecurity/blob/v2/master/modsecurity.conf-recommended) or from [OWASP repository](https://github.com/SpiderLabs/owasp-modsecurity-crs/blob/v3.3/dev/crs-setup.conf.example).
+Use the copied files from the previous code section in your run command:
 ```
-# download and configure conf files in rootfs directory (ex./ crs-setup.conf)
-docker run -p 12345:12345 -v $(pwd):/etc/modsecurity/ quay.io/jcmoraisjr/modsecurity-spoa -n 1 -- /etc/modsecurity/modsecurity.conf /etc/modsecurity/owasp-modsecurity-crs.conf /etc/modsecurity/crs-setup.conf
+docker run -p 12345:12345 -v $(pwd):/root/ quay.io/jcmoraisjr/modsecurity-spoa -n 1 -- /root/modsecurity.conf /root/owasp-modsecurity-crs.conf /root/crs-setup.conf
 ```
 
 ### Running without Config Files

--- a/README.md
+++ b/README.md
@@ -29,15 +29,19 @@ will be used, included in the same order as they have been declared.
 In order to use the default configuration in your customization, you should copy the following files from the image:
 ```
 docker create --name modsec quay.io/jcmoraisjr/modsecurity-spoa
-docker cp modsec:/etc/modsecurity/modsecurity.conf .
-docker cp modsec:/etc/modsecurity/owasp-modsecurity-crs.conf .
+docker cp modsec:/etc/modsecurity .
 docker rm modsec
 ```
 
 Download and customize the configuration files for either the [ModSecurity repository](https://github.com/SpiderLabs/ModSecurity/blob/v2/master/modsecurity.conf-recommended) or from [OWASP repository](https://github.com/SpiderLabs/owasp-modsecurity-crs/blob/v3.3/dev/crs-setup.conf.example).
 Use the copied files from the previous code section in your run command:
 ```
-docker run -p 12345:12345 -v $(pwd):/root/ quay.io/jcmoraisjr/modsecurity-spoa -n 1 -- /root/modsecurity.conf /root/owasp-modsecurity-crs.conf /root/crs-setup.conf
+docker run -p 12345:12345 -v $PWD/modsecurity:/etc/modsecurity quay.io/jcmoraisjr/modsecurity-spoa -n 1
+```
+
+If you do not want to include the default configuration files and only use the configuration files (ex./ custom-config.conf) that you design, leave out the copied default configuration files from before in your run command:
+```
+docker run -p 12345:12345 -v $PWD:/etc/modsecurity/ quay.io/jcmoraisjr/modsecurity-spoa -n 1 -- /etc/modsecurity/custom-config.conf
 ```
 
 ### Running without Config Files

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ docker run -p 12345:12345 -v $PWD/modsecurity:/etc/modsecurity quay.io/jcmoraisj
 
 If you do not want to include the default configuration files and only use the configuration files (ex./ custom-config.conf) that you design, leave out the copied default configuration files from before in your run command:
 ```
-docker run -p 12345:12345 -v $PWD:/etc/modsecurity/ quay.io/jcmoraisjr/modsecurity-spoa -n 1 -- /etc/modsecurity/custom-config.conf
+docker run -p 12345:12345 -v $PWD/modsecurity:/etc/modsecurity quay.io/jcmoraisjr/modsecurity-spoa -n 1 -- /etc/modsecurity/custom-config.conf
 ```
 
 ### Running without Config Files

--- a/README.md
+++ b/README.md
@@ -22,8 +22,54 @@ $ docker run -p 12345:12345 quay.io/jcmoraisjr/modsecurity-spoa [options] [-- <c
 
 `config-files` can be used either after `--` (see above) or from `-f` option (see below).
 The only difference is that the later supports only one filename. All config-files found
-will be used, included in the same order as they have been declared. If no config-file is
-declared, the following will be used:
+will be used, included in the same order as they have been declared.
+
+In order to contain the original rules that are included in the setup without config-files, you should include the following in your `crs-setup.conf` file (if required). Running the Docker image without these included will disable a lot of ModSecurity's default rules.
+
+```
+Include /etc/modsecurity/owasp-modsecurity-crs/rules/REQUEST-900-EXCLUSION-RULES-BEFORE-CRS.conf
+Include /etc/modsecurity/owasp-modsecurity-crs/rules/REQUEST-901-INITIALIZATION.conf
+Include /etc/modsecurity/owasp-modsecurity-crs/rules/REQUEST-903.9001-DRUPAL-EXCLUSION-RULES.conf
+Include /etc/modsecurity/owasp-modsecurity-crs/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
+Include /etc/modsecurity/owasp-modsecurity-crs/rules/REQUEST-903.9003-NEXTCLOUD-EXCLUSION-RULES.conf
+Include /etc/modsecurity/owasp-modsecurity-crs/rules/REQUEST-903.9004-DOKUWIKI-EXCLUSION-RULES.conf
+Include /etc/modsecurity/owasp-modsecurity-crs/rules/REQUEST-903.9005-CPANEL-EXCLUSION-RULES.conf
+Include /etc/modsecurity/owasp-modsecurity-crs/rules/REQUEST-903.9006-XENFORO-EXCLUSION-RULES.conf
+Include /etc/modsecurity/owasp-modsecurity-crs/rules/REQUEST-905-COMMON-EXCEPTIONS.conf
+Include /etc/modsecurity/owasp-modsecurity-crs/rules/REQUEST-910-IP-REPUTATION.conf
+Include /etc/modsecurity/owasp-modsecurity-crs/rules/REQUEST-911-METHOD-ENFORCEMENT.conf
+Include /etc/modsecurity/owasp-modsecurity-crs/rules/REQUEST-912-DOS-PROTECTION.conf
+Include /etc/modsecurity/owasp-modsecurity-crs/rules/REQUEST-913-SCANNER-DETECTION.conf
+Include /etc/modsecurity/owasp-modsecurity-crs/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+Include /etc/modsecurity/owasp-modsecurity-crs/rules/REQUEST-921-PROTOCOL-ATTACK.conf
+Include /etc/modsecurity/owasp-modsecurity-crs/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
+Include /etc/modsecurity/owasp-modsecurity-crs/rules/REQUEST-931-APPLICATION-ATTACK-RFI.conf
+Include /etc/modsecurity/owasp-modsecurity-crs/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
+Include /etc/modsecurity/owasp-modsecurity-crs/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
+Include /etc/modsecurity/owasp-modsecurity-crs/rules/REQUEST-934-APPLICATION-ATTACK-NODEJS.conf
+Include /etc/modsecurity/owasp-modsecurity-crs/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
+Include /etc/modsecurity/owasp-modsecurity-crs/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+Include /etc/modsecurity/owasp-modsecurity-crs/rules/REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION.conf
+Include /etc/modsecurity/owasp-modsecurity-crs/rules/REQUEST-944-APPLICATION-ATTACK-JAVA.conf
+Include /etc/modsecurity/owasp-modsecurity-crs/rules/REQUEST-949-BLOCKING-EVALUATION.conf
+Include /etc/modsecurity/owasp-modsecurity-crs/rules/RESPONSE-950-DATA-LEAKAGES.conf
+Include /etc/modsecurity/owasp-modsecurity-crs/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
+Include /etc/modsecurity/owasp-modsecurity-crs/rules/RESPONSE-952-DATA-LEAKAGES-JAVA.conf
+Include /etc/modsecurity/owasp-modsecurity-crs/rules/RESPONSE-953-DATA-LEAKAGES-PHP.conf
+Include /etc/modsecurity/owasp-modsecurity-crs/rules/RESPONSE-954-DATA-LEAKAGES-IIS.conf
+Include /etc/modsecurity/owasp-modsecurity-crs/rules/RESPONSE-959-BLOCKING-EVALUATION.conf
+Include /etc/modsecurity/owasp-modsecurity-crs/rules/RESPONSE-980-CORRELATION.conf
+Include /etc/modsecurity/owasp-modsecurity-crs/rules/RESPONSE-999-EXCLUSION-RULES-AFTER-CRS.conf
+```
+
+An example of using config files would be.
+```
+cd rootfs
+# download and configure conf files in rootfs directory
+docker run -p 12345:12345 -v $(pwd):/root/ quay.io/jcmoraisjr/modsecurity-spoa -n 1 -- /root/modsecurity.conf /root/crs-setup.conf
+```
+
+If no config-file is declared, the following will be used:
 
 * `/etc/modsecurity/modsecurity.conf`: ModSecurity recommended config, from ModSecurity [repository](https://github.com/SpiderLabs/ModSecurity/tree/v2/master)
     * Changes: `SecRuleEngine`, changed from `DetectionOnly` to `On`


### PR DESCRIPTION
Some improvements for the README.
I was getting lost with configuration files and found that not including the standard rules that are included in the Dockerfile conf file setup was preventing the default functionality to be carried over to custom conf files for the crs and modsecurity.